### PR TITLE
feat: show tracks immediately while loading more in background

### DIFF
--- a/extensions/artistSearch/src/searchModal.tsx
+++ b/extensions/artistSearch/src/searchModal.tsx
@@ -26,12 +26,6 @@ const formatDuration = (ms: number): string => {
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
 };
 
-const formatTime = (ms: number | undefined) => {
-  if (ms == null || ms < 0) return "--:--";
-  const s = Math.floor(ms / 1000);
-  return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`;
-};
-
 const TrackPlaybackControl = ({ uri, duration }: { uri: string; duration: number }) => {
   const {
     position,
@@ -276,7 +270,12 @@ export function ArtistSearchModal({ artistUri, artistName }: Props) {
       </div>
 
       <div className="artist-search-results">
-        {error ? (
+        {loading && filteredTracks.length === 0 ? (
+          <div className="artist-search-loading">
+            <div className="artist-search-spinner" />
+            <span>Loading tracks...</span>
+          </div>
+        ) : error ? (
           <div className="artist-search-error">{error}</div>
         ) : !query.trim() && filteredTracks.length === 0 ? (
           <div className="artist-search-hint">

--- a/extensions/artistSearch/src/searchModal.tsx
+++ b/extensions/artistSearch/src/searchModal.tsx
@@ -165,17 +165,30 @@ export function ArtistSearchModal({ artistUri, artistName }: Props) {
     }
   }, []);
 
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
   useEffect(() => {
+    setTracks([]);
+    setLoading(true);
+    setError(null);
+    setIsLoadingMore(false);
+    
+    let cancelled = false;
+    
     const loadTracks = async () => {
-      setLoading(true);
-      setError(null);
-      setTracks([]);
       await fetchArtistTracks((newTracks) => {
+        if (cancelled) return;
         setTracks((prev) => [...prev, ...newTracks]);
+        setLoading(false);
+        setIsLoadingMore(true);
       });
-      setLoading(false);
+      if (!cancelled) {
+        setIsLoadingMore(false);
+      }
     };
     loadTracks();
+    
+    return () => { cancelled = true; };
   }, [artistUri]);
 
   useEffect(() => {
@@ -256,12 +269,7 @@ export function ArtistSearchModal({ artistUri, artistName }: Props) {
       </div>
 
       <div className="artist-search-results">
-        {loading ? (
-          <div className="artist-search-loading">
-            <div className="artist-search-spinner" />
-            <span>Loading tracks...</span>
-          </div>
-        ) : error ? (
+        {error ? (
           <div className="artist-search-error">{error}</div>
         ) : !query.trim() && filteredTracks.length === 0 ? (
           <div className="artist-search-hint">
@@ -310,6 +318,12 @@ export function ArtistSearchModal({ artistUri, artistName }: Props) {
                 </div>
               ))}
             </div>
+            {isLoadingMore && (
+              <div className="artist-search-loading-more">
+                <div className="artist-search-spinner" />
+                <span>Loading more...</span>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/extensions/artistSearch/src/searchModal.tsx
+++ b/extensions/artistSearch/src/searchModal.tsx
@@ -176,13 +176,20 @@ export function ArtistSearchModal({ artistUri, artistName }: Props) {
     let cancelled = false;
     
     const loadTracks = async () => {
-      await fetchArtistTracks((newTracks) => {
+      try {
+        await fetchArtistTracks((newTracks) => {
+          if (cancelled) return;
+          setTracks((prev) => [...prev, ...newTracks]);
+        });
         if (cancelled) return;
-        setTracks((prev) => [...prev, ...newTracks]);
-        setLoading(false);
         setIsLoadingMore(true);
-      });
-      if (!cancelled) {
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      } finally {
+        if (cancelled) return;
+        setLoading(false);
         setIsLoadingMore(false);
       }
     };

--- a/extensions/artistSearch/src/styles.css
+++ b/extensions/artistSearch/src/styles.css
@@ -117,6 +117,16 @@
   color: var(--spice-error);
 }
 
+.artist-search-loading-more {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--spice-subtext);
+}
+
 .artist-search-spinner {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Description

Display tracks as they load instead of waiting for all albums to be fetched.

## Problem

Opening the menu was slow because it waited for all albums to load before showing any tracks.

## Solution

- Display tracks immediately as they load from each album
- Add loading indicator at the bottom during background loading
- Improve user experience with incremental loading

## Changes

- Modified `searchModal.tsx` to update tracks state incrementally
- Added `isLoadingMore` state to track loading progress
- Added CSS for loading indicator

## Testing

1. Right-click on any artist
2. Verify tracks appear immediately while more load in background

---
**Type of change:** Enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Loading more…" indicator beneath artist track lists for clearer incremental-fetch feedback.
* **Bug Fixes / UX**
  * Improved loading, empty and error state handling so initial load and subsequent "load more" behave distinctly and avoid stale UI updates.
* **Style**
  * Added styling for the "Loading more…" row for consistent spacing and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->