### PR TITLE
Fixes React Compiler runtime resolution

### DIFF
--- a/tasks/build.ts
+++ b/tasks/build.ts
@@ -42,20 +42,12 @@ async function buildExtension(folderName: string, folderPath: string): Promise<v
     sourcemap: "inline",
     minify: false,
     jsx: "automatic",
-external: ["react", "react-dom", "react-dom/client", "react/jsx-runtime", "react-compiler-runtime"],
+    external: ["react", "react-dom", "react-dom/client", "react/jsx-runtime", "react-compiler-runtime"],
     plugins: [
       spicetifyShims(),
       inlineCSSPlugin({
         minify: false,
       }),
-      {
-        name: "resolve-react-compiler-runtime",
-        setup(build) {
-          build.onResolve({ filter: /^react-compiler-runtime$/ }, () => {
-            return { path: "npm:react-compiler-runtime", external: true };
-          });
-        },
-      },
       ...denoPlugins({
         initialPluginData: {
           runtimePackage: "./deno.json",

--- a/tasks/build.ts
+++ b/tasks/build.ts
@@ -42,12 +42,20 @@ async function buildExtension(folderName: string, folderPath: string): Promise<v
     sourcemap: "inline",
     minify: false,
     jsx: "automatic",
-    external: ["react", "react-dom", "react-dom/client", "react/jsx-runtime"],
+external: ["react", "react-dom", "react-dom/client", "react/jsx-runtime", "react-compiler-runtime"],
     plugins: [
       spicetifyShims(),
       inlineCSSPlugin({
         minify: false,
       }),
+      {
+        name: "resolve-react-compiler-runtime",
+        setup(build) {
+          build.onResolve({ filter: /^react-compiler-runtime$/ }, () => {
+            return { path: "npm:react-compiler-runtime", external: true };
+          });
+        },
+      },
       ...denoPlugins({
         initialPluginData: {
           runtimePackage: "./deno.json",


### PR DESCRIPTION
Ensures `react-compiler-runtime` is correctly resolved and treated as an external dependency during the build process. This prevents bundling issues and properly handles the dependency, especially when integrating npm packages within a Deno-based build system.

- Adds `react-compiler-runtime` to the list of external dependencies for esbuild.
- Introduces a custom esbuild plugin to explicitly map `react-compiler-runtime` to `npm:react-compiler-runtime` during resolution, ensuring it is always externalized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the build configuration to exclude one additional runtime dependency from the produced bundle, further reducing bundle size and shifting resolution of that dependency to runtime—improving load performance and build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->