### PR TITLE
chore(deps): update deno dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,10 +18,10 @@
     "@esbuild/": "https://deno.land/x/esbuild@v0.27.2/",
     "@oazmi/esbuild-plugin-deno": "jsr:@oazmi/esbuild-plugin-deno@0.4.5",
 
-    "@std/bytes": "jsr:@std/bytes@^1.0.0",
-    "@std/assert": "jsr:@std/assert@^1.0.0",
-    "@std/path": "jsr:@std/path@^1.0.0",
-    "@std/streams": "jsr:@std/streams@^1.0.0",
+    "@std/bytes": "jsr:@std/bytes@^1.0.6",
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/path": "jsr:@std/path@^1.1.4",
+    "@std/streams": "jsr:@std/streams@^1.0.17",
 
     "esbuild-plugin-babel": "npm:esbuild-plugin-babel@^0.2.3",
     "react": "https://esm.sh/react@19.2.3",

--- a/deno.lock
+++ b/deno.lock
@@ -4,13 +4,11 @@
     "jsr:@oazmi/esbuild-plugin-deno@0.4.5": "0.4.5",
     "jsr:@oazmi/esbuild-types@0.27.0": "0.27.0",
     "jsr:@oazmi/kitchensink@0.9.15": "0.9.15",
-    "jsr:@std/assert@1.0.11": "1.0.11",
-    "jsr:@std/bytes@*": "1.0.6",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/internal@^1.0.5": "1.0.12",
-    "jsr:@std/path@1.1.4": "1.1.4",
-    "jsr:@std/streams@1.0.17": "1.0.17",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/streams@^1.0.17": "1.0.17",
     "npm:@babel/core@7.29.0": "7.29.0",
     "npm:@babel/preset-react@7.28.5": "7.28.5_@babel+core@7.29.0",
     "npm:@babel/preset-typescript@7.28.5": "7.28.5_@babel+core@7.29.0",
@@ -33,10 +31,10 @@
     "@oazmi/kitchensink@0.9.15": {
       "integrity": "01fce611fb67dfe100aaf0e98ac3a039c47b84cf01dd299c0b3647bff88c3d86"
     },
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal@^1.0.5"
+        "jsr:@std/internal"
       ]
     },
     "@std/bytes@1.0.6": {
@@ -48,13 +46,13 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12"
+        "jsr:@std/internal"
       ]
     },
     "@std/streams@1.0.17": {
       "integrity": "7859f3d9deed83cf4b41f19223d4a67661b3d3819e9fc117698f493bf5992140",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.6"
+        "jsr:@std/bytes"
       ]
     }
   },
@@ -527,10 +525,10 @@
   "workspace": {
     "dependencies": [
       "jsr:@oazmi/esbuild-plugin-deno@0.4.5",
-      "jsr:@std/assert@1.0.11",
-      "jsr:@std/bytes@1.0.11",
-      "jsr:@std/path@1.1.4",
-      "jsr:@std/streams@1.0.17",
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/bytes@^1.0.6",
+      "jsr:@std/path@^1.1.4",
+      "jsr:@std/streams@^1.0.17",
       "npm:@babel/core@7.29.0",
       "npm:@babel/preset-react@7.28.5",
       "npm:@babel/preset-typescript@7.28.5",


### PR DESCRIPTION
Automated dependency update via CircleCI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Deno standard library dependencies (bytes, assertions, path utilities, and streams) to latest compatible versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->