### PR TITLE
fix: compress uploaded images before storing in localStorage to avoid QuotaExceededError

### DIFF
--- a/themes/CustomNight/theme.js
+++ b/themes/CustomNight/theme.js
@@ -31,24 +31,33 @@ const LABEL_MAP = {
   'notification': 'Notifications',
 };
 
-function compressImage(dataUrl, maxDimension = 1920, quality = 0.8) {
-  return new Promise((resolve) => {
+function compressImage(dataUrl, maxDimension = 1920, quality = 0.8, fileType) {
+  if (fileType === 'image/gif') {
+    return Promise.resolve(dataUrl);
+  }
+  return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => {
-      let { width, height } = img;
-      if (width > maxDimension || height > maxDimension) {
-        const ratio = Math.min(maxDimension / width, maxDimension / height);
-        width = Math.round(width * ratio);
-        height = Math.round(height * ratio);
+      try {
+        let { width, height } = img;
+        if (width > maxDimension || height > maxDimension) {
+          const ratio = Math.min(maxDimension / width, maxDimension / height);
+          width = Math.round(width * ratio);
+          height = Math.round(height * ratio);
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('Failed to get canvas 2d context');
+        ctx.drawImage(img, 0, 0, width, height);
+        const outputType = fileType === 'image/png' ? 'image/png' : 'image/jpeg';
+        resolve(canvas.toDataURL(outputType, quality));
+      } catch (err) {
+        reject(err);
       }
-      const canvas = document.createElement('canvas');
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(img, 0, 0, width, height);
-      resolve(canvas.toDataURL('image/jpeg', quality));
     };
-    img.onerror = () => resolve(dataUrl);
+    img.onerror = () => reject(new Error('Failed to load image for compression'));
     img.src = dataUrl;
   });
 }
@@ -72,12 +81,14 @@ function setCustomBackgroundUrl(url) {
     } else {
       localStorage.removeItem(STORAGE_KEY);
     }
+    return true;
   } catch (e) {
     if (e.name === 'QuotaExceededError') {
       Spicetify?.showNotification?.('Image too large after compression. Try a smaller image or use a URL instead.', true);
     } else {
       console.error('Failed to save custom background:', e);
     }
+    return false;
   }
 }
 
@@ -361,39 +372,53 @@ function customBackgroundInit() {
       if (fileInput) {
         fileInput.addEventListener('change', async (e) => {
           const file = e.target.files?.[0];
-          if (file) {
-            if (file.size > 30 * 1024 * 1024) {
-              Spicetify?.showNotification?.('Large image (>30MB): compression may take a moment...', false);
-            }
-            const objectUrl = URL.createObjectURL(file);
-            try {
-              const compressed = await compressImage(objectUrl);
-              if (!compressed || compressed === objectUrl) {
-                Spicetify?.showNotification?.('Could not process this image. Try a different format.', true);
-                return;
+          if (!file) return;
+
+          const handleUploadedImage = (url) => {
+            currentUrl = url;
+            bgPositionX = 50;
+            bgPositionY = 50;
+            bgSize = 100;
+            if (sizeSlider) sizeSlider.value = 100;
+            if (sizeVal) sizeVal.textContent = '100%';
+            if (currentEl) currentEl.textContent = 'Current: Local file';
+            updatePreview();
+          };
+
+          if (file.type === 'image/gif') {
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+              const dataUrl = ev.target?.result;
+              if (typeof dataUrl === 'string') {
+                handleUploadedImage(dataUrl);
               }
-              currentUrl = compressed;
-              bgPositionX = 50;
-              bgPositionY = 50;
-              bgSize = 100;
-              if (sizeSlider) sizeSlider.value = 100;
-              if (sizeVal) sizeVal.textContent = '100%';
-              if (currentEl) currentEl.textContent = 'Current: Local file';
-              updatePreview();
-              if (confirm('Auto-detect accent colors from this image?')) {
-                const extracted = await extractColorsFromImage(compressed);
-                if (extracted) {
-                  const pickerIds = Object.keys(DEFAULT_ACCENT);
-                  for (let i = 0; i < Math.min(extracted.length, pickerIds.length); i++) {
-                    const picker = content.querySelector(`#customnight-color-${pickerIds[i]}`);
-                    if (picker) picker.value = extracted[i].hex;
-                  }
-                  Spicetify?.showNotification?.('Colors auto-detected from image!');
+            };
+            reader.readAsDataURL(file);
+            return;
+          }
+
+          if (file.size > 30 * 1024 * 1024) {
+            Spicetify?.showNotification?.('Large image (>30MB): compression may take a moment...', false);
+          }
+          const objectUrl = URL.createObjectURL(file);
+          try {
+            const compressed = await compressImage(objectUrl, 1920, 0.8, file.type);
+            handleUploadedImage(compressed);
+            if (confirm('Auto-detect accent colors from this image?')) {
+              const extracted = await extractColorsFromImage(compressed);
+              if (extracted) {
+                const pickerIds = Object.keys(DEFAULT_ACCENT);
+                for (let i = 0; i < Math.min(extracted.length, pickerIds.length); i++) {
+                  const picker = content.querySelector(`#customnight-color-${pickerIds[i]}`);
+                  if (picker) picker.value = extracted[i].hex;
                 }
+                Spicetify?.showNotification?.('Colors auto-detected from image!');
               }
-            } finally {
-              URL.revokeObjectURL(objectUrl);
             }
+          } catch (err) {
+            Spicetify?.showNotification?.('Could not process this image. Try a different format.', true);
+          } finally {
+            URL.revokeObjectURL(objectUrl);
           }
         });
       }
@@ -427,7 +452,8 @@ function customBackgroundInit() {
           setAccentColors(colors);
           applyAccentColors(colors);
           if (url) {
-            setCustomBackgroundUrl(url);
+            const saved = setCustomBackgroundUrl(url);
+            if (!saved) return;
             setBackgroundSettings(bgSize, bgPositionX, bgPositionY);
             const container = document.querySelector('.customnight-bg-container');
             if (container) {

--- a/themes/CustomNight/theme.js
+++ b/themes/CustomNight/theme.js
@@ -31,6 +31,28 @@ const LABEL_MAP = {
   'notification': 'Notifications',
 };
 
+function compressImage(dataUrl, maxDimension = 1920, quality = 0.8) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+      if (width > maxDimension || height > maxDimension) {
+        const ratio = Math.min(maxDimension / width, maxDimension / height);
+        width = Math.round(width * ratio);
+        height = Math.round(height * ratio);
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, width, height);
+      resolve(canvas.toDataURL('image/jpeg', quality));
+    };
+    img.onerror = () => resolve(dataUrl);
+    img.src = dataUrl;
+  });
+}
+
 function escapeForCssUrl(url) {
   return url.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\)/g, '\\)');
 }
@@ -51,7 +73,11 @@ function setCustomBackgroundUrl(url) {
       localStorage.removeItem(STORAGE_KEY);
     }
   } catch (e) {
-    console.error('Failed to save custom background:', e);
+    if (e.name === 'QuotaExceededError') {
+      Spicetify?.showNotification?.('Image too large after compression. Try a smaller image or use a URL instead.', true);
+    } else {
+      console.error('Failed to save custom background:', e);
+    }
   }
 }
 
@@ -336,32 +362,38 @@ function customBackgroundInit() {
         fileInput.addEventListener('change', async (e) => {
           const file = e.target.files?.[0];
           if (file) {
-            const reader = new FileReader();
-            reader.onload = async (ev) => {
-              const dataUrl = ev.target?.result;
-              if (typeof dataUrl === 'string') {
-                currentUrl = dataUrl;
-                bgPositionX = 50;
-                bgPositionY = 50;
-                bgSize = 100;
-                if (sizeSlider) sizeSlider.value = 100;
-                if (sizeVal) sizeVal.textContent = '100%';
-                if (currentEl) currentEl.textContent = 'Current: Local file (base64)';
-                updatePreview();
-                if (confirm('Auto-detect accent colors from this image?')) {
-                  const extracted = await extractColorsFromImage(dataUrl);
-                  if (extracted) {
-                    const pickerIds = Object.keys(DEFAULT_ACCENT);
-                    for (let i = 0; i < Math.min(extracted.length, pickerIds.length); i++) {
-                      const picker = content.querySelector(`#customnight-color-${pickerIds[i]}`);
-                      if (picker) picker.value = extracted[i].hex;
-                    }
-                    Spicetify?.showNotification?.('Colors auto-detected from image!');
+            if (file.size > 30 * 1024 * 1024) {
+              Spicetify?.showNotification?.('Large image (>30MB): compression may take a moment...', false);
+            }
+            const objectUrl = URL.createObjectURL(file);
+            try {
+              const compressed = await compressImage(objectUrl);
+              if (!compressed || compressed === objectUrl) {
+                Spicetify?.showNotification?.('Could not process this image. Try a different format.', true);
+                return;
+              }
+              currentUrl = compressed;
+              bgPositionX = 50;
+              bgPositionY = 50;
+              bgSize = 100;
+              if (sizeSlider) sizeSlider.value = 100;
+              if (sizeVal) sizeVal.textContent = '100%';
+              if (currentEl) currentEl.textContent = 'Current: Local file';
+              updatePreview();
+              if (confirm('Auto-detect accent colors from this image?')) {
+                const extracted = await extractColorsFromImage(compressed);
+                if (extracted) {
+                  const pickerIds = Object.keys(DEFAULT_ACCENT);
+                  for (let i = 0; i < Math.min(extracted.length, pickerIds.length); i++) {
+                    const picker = content.querySelector(`#customnight-color-${pickerIds[i]}`);
+                    if (picker) picker.value = extracted[i].hex;
                   }
+                  Spicetify?.showNotification?.('Colors auto-detected from image!');
                 }
               }
-            };
-            reader.readAsDataURL(file);
+            } finally {
+              URL.revokeObjectURL(objectUrl);
+            }
           }
         });
       }


### PR DESCRIPTION
Large images (>40MB) exceeded localStorage quota when stored as base64.
- Replaced FileReader.readAsDataURL with URL.createObjectURL to avoid intermediate base64 blowup
- Added compressImage() function: resizes to max 1920px and re-encodes as JPEG quality 0.8 via canvas
- Added file size warning for images >30MB
- Added proper error notification for QuotaExceededError fallback
- Revokes object URL after compression to free memory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background image uploads are now automatically compressed for efficient storage.
  * Accent colors are auto-detected from background images.

* **Bug Fixes**
  * Custom background save failures now display a user-friendly error message when storage quota is exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JimMarley420/spicetify-extension/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->